### PR TITLE
Generate a valueOf function to extract a subtype based on a string

### DIFF
--- a/src/main/scala/generate/MetaGenerator.scala
+++ b/src/main/scala/generate/MetaGenerator.scala
@@ -88,12 +88,23 @@ case class GeneratedEnumeration(
   fields: SortedSet[GeneratedEnumField],
   definedIn: File
 ) extends GeneratedDefinition {
+
+  def generateMatchCase(field: GeneratedEnumField): String = {
+    val name = field.name.generate
+    s"""case "${name.toLowerCase}" => Some(${name.toLowerCase.capitalize})"""
+  }
+
   lazy val fieldStr = fields.toSeq.map(f => f.generate)
-  lazy val generate =
-    s"""sealed trait ${name.generate} {val identifier: Int} \n
+  lazy val matchCases = fields.map(f => generateMatchCase(f))
+  lazy val generate = s"""sealed trait ${name.generate} {val identifier: Int} \n
        | object ${name.generate} { \n
-       | ${fieldStr.mkString("; ")} }""".stripMargin
+       | ${fieldStr.mkString("; ")} \n
+       | def valueOf(name: String): Option[${name.generate}] = name.toLowerCase match { \n
+       | ${matchCases.mkString("\n")} \n
+       | case _ => None } \n
+       | }""".stripMargin
 }
+
 case class GeneratedPackage(
   definitions: Set[GeneratedDefinition],
   name: Option[Identifier] = None

--- a/src/sbt-test/thrift-transform/change-package-name/src/main/scala/SimpleConsumer.scala
+++ b/src/sbt-test/thrift-transform/change-package-name/src/main/scala/SimpleConsumer.scala
@@ -8,4 +8,7 @@ class SimpleConsumer {
   val x1 = SimpleStruct(name = None, age = Some(10))
   val x2 = OtherSimpleStruct(number = Some(5.6))
   val e1: SimpleEnum = SimpleEnum.Yes
+  val e2: Option[SimpleEnum] = SimpleEnum.valueOf("yes")
+  val e3: SimpleEnum = e2.get
+  val e4: Option[SimpleEnum] = SimpleEnum.valueOf("other")
 }


### PR DESCRIPTION
When [Scrooge](https://twitter.github.io/scrooge/) generates scala code from thrift enums it provides a valueOf function that takes a string and returns an Option of a subtype or None